### PR TITLE
Congela a versão do python 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Felipe Markson <fmarkson@outlook.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "~3.7"
 "OpenDSSDirect.py" = {extras = ["extras"], version = "^0.3.7"}
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Devido aos problemas reportado nesta issue do [OpenDSSDirect.py](https://github.com/dss-extensions/OpenDSSDirect.py/issues/81) a versão do python está congelada no 3.7